### PR TITLE
Fix a typing error of comments in pfb11-18

### DIFF
--- a/python-for-beginners/13 - Functions/code_challenge_solution.py
+++ b/python-for-beginners/13 - Functions/code_challenge_solution.py
@@ -5,8 +5,6 @@
 # operation: the word 'add' or 'subtract'
 # the function should return the result of the two numbers added or subtracted
 # based on the value passed in for the operator
-#
-
 def calculator(first_number, second_number, operation):
     if operation.upper() == 'ADD':
         return(float(first_number) + float(second_number))
@@ -16,7 +14,6 @@ def calculator(first_number, second_number, operation):
         return('Invalid operation please specify ADD or SUBTRACT')
 # Test your function with the values 6,4, add 
 # Should return 10
-#
 print('Adding 6 + 4 = ' + str(calculator(6,4,'add')))
 # Test your function with the values 6,4, subtract 
 # Should return 2

--- a/python-for-beginners/13 - Functions/get_initials_function.py
+++ b/python-for-beginners/13 - Functions/get_initials_function.py
@@ -1,0 +1,25 @@
+# Create function get_initial to accept a name and 
+# return the first letter of the name in uppercase
+# Parameters:
+#   name: the name of a person
+# Return value:
+#   first letter of name passed in as a parameter in uppercase 
+def get_initial(name):
+    initial = name[0:1].upper()
+    return initial
+
+# This program will ask for someone's name and return the initials
+first_name = input('Enter your first name: ')
+# Call get_initial to retrieve initial of name
+first_name_initial = get_initial(first_name)
+
+middle_name = input('Enter your middle name: ')
+# Call get_initial to retrieve initial of name
+middle_name_initial = get_initial(middle_name)
+
+last_name = input('Enter your last name: ')
+# Call get_initial to retrieve initial of name
+last_name_initial = get_initial(last_name)
+
+print('Your initials are: ' + first_name_initial \
+    + middle_name_initial + last_name_initial)

--- a/python-for-beginners/13 - Functions/getting_clever_with_functions_harder_to_read.py
+++ b/python-for-beginners/13 - Functions/getting_clever_with_functions_harder_to_read.py
@@ -8,7 +8,7 @@ def get_initial(name):
     initial = name[0:1].upper()
     return initial
 
-#Ask for someone's name and return the initials
+# Ask for someone's name and return the initials
 first_name = input('Enter your first name: ')
 middle_name = input('Enter your middle name: ')
 last_name = input('Enter your last name: ')

--- a/python-for-beginners/14 - Function parameters/code_challenge_solution.py
+++ b/python-for-beginners/14 - Function parameters/code_challenge_solution.py
@@ -5,7 +5,6 @@
 # operation: the word 'add' or 'subtract'. The default operation is 'add'
 # the function should return the result of the two numbers added or subtracted
 # based on the value passed in for the operator
-#
 def calculator(first_number, second_number, operation='ADD'):
     if operation.upper() == 'ADD':
         return(float(first_number) + float(second_number))
@@ -17,9 +16,7 @@ def calculator(first_number, second_number, operation='ADD'):
 
 # Test your function using named notation passing in only the numbers 6 and 4
 # Should return 10
-
 print('Adding 6 + 4 = ' + str(calculator(first_number=6, second_number=4)))
-# Test your function using named notation with the values 6,4, subtract 
+# Test your function using named notation with the values 6, 4, and subtract 
 # Should return 2
-#
 print('Subtracting 6 - 4 = ' + str(calculator(first_number=6, second_number=4, operation='subtract')))

--- a/python-for-beginners/14 - Function parameters/get_initials_function.py
+++ b/python-for-beginners/14 - Function parameters/get_initials_function.py
@@ -1,4 +1,4 @@
-# This function will take a name and return the 
+# This function will take a name and return the first initial of a name
 # Create a function to return the first initial of a name
 # Parameters:
 #   name: name of person

--- a/python-for-beginners/14 - Function parameters/get_initials_multiple_parameters.py
+++ b/python-for-beginners/14 - Function parameters/get_initials_multiple_parameters.py
@@ -11,11 +11,11 @@ def get_initial(name, force_uppercase):
         initial = name[0:1]
     return initial
 
-#Ask for someone's name and return the initial
+# Ask for someone's name and return the initials
 first_name = input('Enter your first name: ')
 
 # Call get_initial function to retrieve first letter of name
-# Alwasy return initial in uppercase
+# Always return initial in uppercase
 first_name_initial = get_initial(first_name, False)
 
 print('Your initial is: ' + first_name_initial)

--- a/python-for-beginners/14 - Function parameters/get_initials_named_parameters.py
+++ b/python-for-beginners/14 - Function parameters/get_initials_named_parameters.py
@@ -11,7 +11,7 @@ def get_initial(name, force_uppercase):
         initial = name[0:1]
     return initial
 
-# Ask for someone's name and return the initial
+# Ask for someone's name and return the initials
 first_name = input('Enter your first name: ')
 
 # Call get_initial to retrieve first letter of name

--- a/python-for-beginners/14 - Function parameters/named_parameters_make_code_readable.py
+++ b/python-for-beginners/14 - Function parameters/named_parameters_make_code_readable.py
@@ -9,7 +9,7 @@
 #                   2 - warning code can continue but may be missing information in records
 #   log_to_db: Should this error be logged to the database 
 #   error_message: Error message to display to user and write to database
-#   source_module: Name of the python module that generated ther error
+#   source_module: Name of the python module that generated the error
 
 def error_logger(error_code, error_severity, log_to_db, error_message, source_module):
     print('oh no error: ' + error_message)

--- a/python-for-beginners/16 - Calling APIs/call_api.py
+++ b/python-for-beginners/16 - Calling APIs/call_api.py
@@ -1,5 +1,5 @@
 # This code will show you how to call the Computer Vision API from Python
-# You can find documentation on the Computer Vision Analyzing Image method here
+# You can find documentation on the Computer Vision Analyze Image method here
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
 
 # Use the requests library to simplify making a REST API call from Python 
@@ -20,7 +20,7 @@ vision_service_address = "https://canadacentral.api.cognitive.microsoft.com/visi
 # Add the name of the function you want to call to the address
 address = vision_service_address + "analyze"
 
-# According to the documentation for the analyzing image function, 
+# According to the documentation for the analyze image function, 
 # there are three optional parameters: language, details & visualFeatures
 parameters  = {'visualFeatures':'Description,Color',
                'language':'en'}
@@ -29,13 +29,13 @@ parameters  = {'visualFeatures':'Description,Color',
 image_path = "./TestImages/PolarBear.jpg"
 image_data = open(image_path, "rb").read()
 
-# According to the documentation for the analyzing image function,
+# According to the documentation for the analyze image function,
 # we need to specify the subscription key and the content type
 # in the HTTP header. Content-Type is application/octet-stream when you pass in a image directly
 headers    = {'Content-Type': 'application/octet-stream',
               'Ocp-Apim-Subscription-Key': SUBSCRIPTION_KEY}
 
-# According to the documentation for the analyzing image function,
+# According to the documentation for the analyze image function,
 # we use HTTP POST to call this function
 response = requests.post(address, headers=headers, params=parameters, data=image_data)
 

--- a/python-for-beginners/16 - Calling APIs/call_api.py
+++ b/python-for-beginners/16 - Calling APIs/call_api.py
@@ -1,5 +1,5 @@
 # This code will show you how to call the Computer Vision API from Python
-# You can find documentation on the Computer Vision Analyze Image method here
+# You can find documentation on the Computer Vision Analyzing Image method here
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
 
 # Use the requests library to simplify making a REST API call from Python 
@@ -10,7 +10,7 @@ import requests
 import json
 
 # You need to update the SUBSCRIPTION_KEY to 
-# they key for your Computer Vision Service
+# the key for your Computer Vision Service
 SUBSCRIPTION_KEY = "xxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 # You need to update the vision_service_address to the address of
@@ -20,8 +20,8 @@ vision_service_address = "https://canadacentral.api.cognitive.microsoft.com/visi
 # Add the name of the function you want to call to the address
 address = vision_service_address + "analyze"
 
-# According to the documentation for the analyze image function 
-# There are three optional parameters: language, details & visualFeatures
+# According to the documentation for the analyzing image function, 
+# there are three optional parameters: language, details & visualFeatures
 parameters  = {'visualFeatures':'Description,Color',
                'language':'en'}
 
@@ -29,13 +29,13 @@ parameters  = {'visualFeatures':'Description,Color',
 image_path = "./TestImages/PolarBear.jpg"
 image_data = open(image_path, "rb").read()
 
-# According to the documentation for the analyze image function
+# According to the documentation for the analyzing image function,
 # we need to specify the subscription key and the content type
 # in the HTTP header. Content-Type is application/octet-stream when you pass in a image directly
 headers    = {'Content-Type': 'application/octet-stream',
               'Ocp-Apim-Subscription-Key': SUBSCRIPTION_KEY}
 
-# According to the documentation for the analyze image function
+# According to the documentation for the analyzing image function,
 # we use HTTP POST to call this function
 response = requests.post(address, headers=headers, params=parameters, data=image_data)
 

--- a/python-for-beginners/16 - Calling APIs/code_challenge.py
+++ b/python-for-beginners/16 - Calling APIs/code_challenge.py
@@ -12,7 +12,7 @@
 # Your skills are growing, it's time to start trying to figure things out on your own
 # based on documentation. You have already called one function of the Computer Vision Service
 # Now try calling another
-# Instead of calling the analyzing method of the service, try calling the OCR method 
+# Instead of calling the analyze method of the service, try calling the OCR method 
 # Here is some helpful documentation
 # https://docs.microsoft.com/azure/cognitive-services/Computer-vision/concept-recognizing-text#ocr-optical-character-recognition-api
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fc

--- a/python-for-beginners/16 - Calling APIs/code_challenge.py
+++ b/python-for-beginners/16 - Calling APIs/code_challenge.py
@@ -12,7 +12,7 @@
 # Your skills are growing, it's time to start trying to figure things out on your own
 # based on documentation. You have already called one function of the Computer Vision Service
 # Now try calling another
-# Instead of calling the analyze method of the service, try calling the OCR method 
+# Instead of calling the analyzing method of the service, try calling the OCR method 
 # Here is some helpful documentation
 # https://docs.microsoft.com/azure/cognitive-services/Computer-vision/concept-recognizing-text#ocr-optical-character-recognition-api
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fc

--- a/python-for-beginners/17 - JSON/create_json_with_nested_dict.py
+++ b/python-for-beginners/17 - JSON/create_json_with_nested_dict.py
@@ -5,8 +5,8 @@ person_dict = {'first': 'Christopher', 'last':'Harrison'}
 # Add additional key pairs to dictionary as needed
 person_dict['City']='Seattle'
 
-# create a staff dictionary
-# assign a person to a staff position of program manager
+# Create a staff dictionary
+# Assign a person to a staff position of program manager
 staff_dict ={}
 staff_dict['Program Manager']=person_dict
 # Convert dictionary to JSON object

--- a/python-for-beginners/17 - JSON/read_json.py
+++ b/python-for-beginners/17 - JSON/read_json.py
@@ -1,5 +1,5 @@
 # This code will show you how to call the Computer Vision API from Python
-# You can find documentation on the Computer Vision Analyzing Image method here
+# You can find documentation on the Computer Vision Analyze Image method here
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
 
 # Use the requests library to simplify making a REST API call from Python 
@@ -14,7 +14,7 @@ vision_service_address = "https://canadacentral.api.cognitive.microsoft.com/visi
 # Add the name of the function we want to call to the address
 address = vision_service_address + "analyze"
 
-# According to the documentation for the analyzing image function, 
+# According to the documentation for the analyze image function, 
 # there are three optional parameters: language, details & visualFeatures
 parameters  = {'visualFeatures':'Description,Color',
                'language':'en'}
@@ -26,13 +26,13 @@ subscription_key = "cf229a23c3054905b5a8ad512edfa9dd"
 image_path = "./TestImages/PolarBear.jpg"
 image_data = open(image_path, 'rb').read()
 
-# According to the documentation for the analyzing image function,
+# According to the documentation for the analyze image function,
 # we need to specify the subscription key and the content type
 # in the HTTP header. Content-Type is application/octet-stream when you pass in a image directly
 headers    = {'Content-Type': 'application/octet-stream',
               'Ocp-Apim-Subscription-Key': subscription_key}
 
-# According to the documentation for the analyzing image function,
+# According to the documentation for the analyze image function,
 # we use HTTP POST to call this function
 response = requests.post(address, headers=headers, params=parameters, data=image_data)
 

--- a/python-for-beginners/17 - JSON/read_json.py
+++ b/python-for-beginners/17 - JSON/read_json.py
@@ -1,5 +1,5 @@
 # This code will show you how to call the Computer Vision API from Python
-# You can find documentation on the Computer Vision Analyze Image method here
+# You can find documentation on the Computer Vision Analyzing Image method here
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
 
 # Use the requests library to simplify making a REST API call from Python 
@@ -9,13 +9,13 @@ import requests
 # by the web service
 import json
 
-# We need the address of our Computer vision service
+# We need the address of our Computer Vision Service
 vision_service_address = "https://canadacentral.api.cognitive.microsoft.com/vision/v2.0/"
 # Add the name of the function we want to call to the address
 address = vision_service_address + "analyze"
 
-# According to the documentation for the analyze image function 
-# There are three optional parameters: language, details & visualFeatures
+# According to the documentation for the analyzing image function, 
+# there are three optional parameters: language, details & visualFeatures
 parameters  = {'visualFeatures':'Description,Color',
                'language':'en'}
 
@@ -26,13 +26,13 @@ subscription_key = "cf229a23c3054905b5a8ad512edfa9dd"
 image_path = "./TestImages/PolarBear.jpg"
 image_data = open(image_path, 'rb').read()
 
-# According to the documentation for the analyze image function
+# According to the documentation for the analyzing image function,
 # we need to specify the subscription key and the content type
 # in the HTTP header. Content-Type is application/octet-stream when you pass in a image directly
 headers    = {'Content-Type': 'application/octet-stream',
               'Ocp-Apim-Subscription-Key': subscription_key}
 
-# According to the documentation for the analyze image function
+# According to the documentation for the analyzing image function,
 # we use HTTP POST to call this function
 response = requests.post(address, headers=headers, params=parameters, data=image_data)
 

--- a/python-for-beginners/17 - JSON/read_key_pair.py
+++ b/python-for-beginners/17 - JSON/read_key_pair.py
@@ -1,5 +1,5 @@
 # This code will show you how to call the Computer Vision API from Python
-# You can find documentation on the Computer Vision Analyze Image method here
+# You can find documentation on the Computer Vision Analyzing Image method here
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
 
 # Use the requests library to simplify making a REST API call from Python 
@@ -9,13 +9,13 @@ import requests
 # by the web service
 import json
 
-# We need the address of our Computer vision service
+# We need the address of our Computer Vision Service
 vision_service_address = "https://canadacentral.api.cognitive.microsoft.com/vision/v2.0/"
 # Add the name of the function we want to call to the address
 address = vision_service_address + "analyze"
 
-# According to the documentation for the analyze image function 
-# There are three optional parameters: language, details & visualFeatures
+# According to the documentation for the analyzing image function, 
+# there are three optional parameters: language, details & visualFeatures
 parameters  = {'visualFeatures':'Description,Color',
                'language':'en'}
 
@@ -26,13 +26,13 @@ subscription_key = "xxxxxxxxxxxxxxxxxxxx"
 image_path = "./TestImages/PolarBear.jpg"
 image_data = open(image_path, 'rb').read()
 
-# According to the documentation for the analyze image function
+# According to the documentation for the analyzing image function,
 # we need to specify the subscription key and the content type
 # in the HTTP header. Content-Type is application/octet-stream when you pass in a image directly
 headers    = {'Content-Type': 'application/octet-stream',
               'Ocp-Apim-Subscription-Key': subscription_key}
 
-# According to the documentation for the analyze image function
+# According to the documentation for the analyzing image function,
 # we use HTTP POST to call this function
 response = requests.post(address, headers=headers, params=parameters, data=image_data)
 
@@ -43,7 +43,7 @@ response.raise_for_status()
 results = response.json()
 print(json.dumps(results))
 
-# print the value for requestId from the JSON output
+# Print the value for requestId from the JSON output
 print()
 print('requestId')
 print (results['requestId'])

--- a/python-for-beginners/17 - JSON/read_key_pair.py
+++ b/python-for-beginners/17 - JSON/read_key_pair.py
@@ -1,5 +1,5 @@
 # This code will show you how to call the Computer Vision API from Python
-# You can find documentation on the Computer Vision Analyzing Image method here
+# You can find documentation on the Computer Vision Analyze Image method here
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
 
 # Use the requests library to simplify making a REST API call from Python 
@@ -14,7 +14,7 @@ vision_service_address = "https://canadacentral.api.cognitive.microsoft.com/visi
 # Add the name of the function we want to call to the address
 address = vision_service_address + "analyze"
 
-# According to the documentation for the analyzing image function, 
+# According to the documentation for the analyze image function, 
 # there are three optional parameters: language, details & visualFeatures
 parameters  = {'visualFeatures':'Description,Color',
                'language':'en'}
@@ -26,13 +26,13 @@ subscription_key = "xxxxxxxxxxxxxxxxxxxx"
 image_path = "./TestImages/PolarBear.jpg"
 image_data = open(image_path, 'rb').read()
 
-# According to the documentation for the analyzing image function,
+# According to the documentation for the analyze image function,
 # we need to specify the subscription key and the content type
 # in the HTTP header. Content-Type is application/octet-stream when you pass in a image directly
 headers    = {'Content-Type': 'application/octet-stream',
               'Ocp-Apim-Subscription-Key': subscription_key}
 
-# According to the documentation for the analyzing image function,
+# According to the documentation for the analyze image function,
 # we use HTTP POST to call this function
 response = requests.post(address, headers=headers, params=parameters, data=image_data)
 

--- a/python-for-beginners/17 - JSON/read_key_pair_list.py
+++ b/python-for-beginners/17 - JSON/read_key_pair_list.py
@@ -1,5 +1,5 @@
 # This code will show you how to call the Computer Vision API from Python
-# You can find documentation on the Computer Vision Analyze Image method here
+# You can find documentation on the Computer Vision Analyzing Image method here
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
 
 # Use the requests library to simplify making a REST API call from Python 
@@ -9,13 +9,13 @@ import requests
 # by the web service
 import json
 
-# We need the address of our Computer vision service
+# We need the address of our Computer Vision Service
 vision_service_address = "https://canadacentral.api.cognitive.microsoft.com/vision/v2.0/"
 # Add the name of the function we want to call to the address
 address = vision_service_address + "analyze"
 
-# According to the documentation for the analyze image function 
-# There are three optional parameters: language, details & visualFeatures
+# According to the documentation for the analyzing image function, 
+# there are three optional parameters: language, details & visualFeatures
 parameters  = {'visualFeatures':'Description,Color',
                'language':'en'}
 
@@ -26,13 +26,13 @@ subscription_key = "xxxxxxxxxxxxxxxxxxxxxxx"
 image_path = "./TestImages/PolarBear.jpg"
 image_data = open(image_path, 'rb').read()
 
-# According to the documentation for the analyze image function
+# According to the documentation for the analyzing image function,
 # we need to specify the subscription key and the content type
 # in the HTTP header. Content-Type is application/octet-stream when you pass in a image directly
 headers    = {'Content-Type': 'application/octet-stream',
               'Ocp-Apim-Subscription-Key': subscription_key}
 
-# According to the documentation for the analyze image function
+# According to the documentation for the analyzing image function,
 # we use HTTP POST to call this function
 response = requests.post(address, headers=headers, params=parameters, data=image_data)
 
@@ -49,7 +49,7 @@ print('all tags')
 for item in results['description']['tags']:
     print(item)
 
-# print out the first tag in the description
+# Print out the first tag in the description
 print()
 print('first_tag')
 print(results['description']['tags'][0])

--- a/python-for-beginners/17 - JSON/read_key_pair_list.py
+++ b/python-for-beginners/17 - JSON/read_key_pair_list.py
@@ -1,5 +1,5 @@
 # This code will show you how to call the Computer Vision API from Python
-# You can find documentation on the Computer Vision Analyzing Image method here
+# You can find documentation on the Computer Vision Analyze Image method here
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
 
 # Use the requests library to simplify making a REST API call from Python 
@@ -14,7 +14,7 @@ vision_service_address = "https://canadacentral.api.cognitive.microsoft.com/visi
 # Add the name of the function we want to call to the address
 address = vision_service_address + "analyze"
 
-# According to the documentation for the analyzing image function, 
+# According to the documentation for the analyze image function, 
 # there are three optional parameters: language, details & visualFeatures
 parameters  = {'visualFeatures':'Description,Color',
                'language':'en'}
@@ -26,13 +26,13 @@ subscription_key = "xxxxxxxxxxxxxxxxxxxxxxx"
 image_path = "./TestImages/PolarBear.jpg"
 image_data = open(image_path, 'rb').read()
 
-# According to the documentation for the analyzing image function,
+# According to the documentation for the analyze image function,
 # we need to specify the subscription key and the content type
 # in the HTTP header. Content-Type is application/octet-stream when you pass in a image directly
 headers    = {'Content-Type': 'application/octet-stream',
               'Ocp-Apim-Subscription-Key': subscription_key}
 
-# According to the documentation for the analyzing image function,
+# According to the documentation for the analyze image function,
 # we use HTTP POST to call this function
 response = requests.post(address, headers=headers, params=parameters, data=image_data)
 

--- a/python-for-beginners/17 - JSON/read_subkey.py
+++ b/python-for-beginners/17 - JSON/read_subkey.py
@@ -1,5 +1,5 @@
 # This code will show you how to call the Computer Vision API from Python
-# You can find documentation on the Computer Vision Analyze Image method here
+# You can find documentation on the Computer Vision Analyzing Image method here
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
 
 # Use the requests library to simplify making a REST API call from Python 
@@ -9,13 +9,13 @@ import requests
 # by the web service
 import json
 
-# We need the address of our Computer vision service
+# We need the address of our Computer Vision Service
 vision_service_address = "https://canadacentral.api.cognitive.microsoft.com/vision/v2.0/"
 # Add the name of the function we want to call to the address
 address = vision_service_address + "analyze"
 
-# According to the documentation for the analyze image function 
-# There are three optional parameters: language, details & visualFeatures
+# According to the documentation for the analyzing image function, 
+# there are three optional parameters: language, details & visualFeatures
 parameters  = {'visualFeatures':'Description,Color',
                'language':'en'}
 
@@ -26,13 +26,13 @@ subscription_key = "xxxxxxxxxxxxxxxxxxxxxxx"
 image_path = "./TestImages/PolarBear.jpg"
 image_data = open(image_path, 'rb').read()
 
-# According to the documentation for the analyze image function
+# According to the documentation for the analyzing image function,
 # we need to specify the subscription key and the content type
 # in the HTTP header. Content-Type is application/octet-stream when you pass in a image directly
 headers    = {'Content-Type': 'application/octet-stream',
               'Ocp-Apim-Subscription-Key': subscription_key}
 
-# According to the documentation for the analyze image function
+# According to the documentation for the analyzing image function,
 # we use HTTP POST to call this function
 response = requests.post(address, headers=headers, params=parameters, data=image_data)
 

--- a/python-for-beginners/17 - JSON/read_subkey.py
+++ b/python-for-beginners/17 - JSON/read_subkey.py
@@ -1,5 +1,5 @@
 # This code will show you how to call the Computer Vision API from Python
-# You can find documentation on the Computer Vision Analyzing Image method here
+# You can find documentation on the Computer Vision Analyze Image method here
 # https://westus.dev.cognitive.microsoft.com/docs/services/5adf991815e1060e6355ad44/operations/56f91f2e778daf14a499e1fa
 
 # Use the requests library to simplify making a REST API call from Python 
@@ -14,7 +14,7 @@ vision_service_address = "https://canadacentral.api.cognitive.microsoft.com/visi
 # Add the name of the function we want to call to the address
 address = vision_service_address + "analyze"
 
-# According to the documentation for the analyzing image function, 
+# According to the documentation for the analyze image function, 
 # there are three optional parameters: language, details & visualFeatures
 parameters  = {'visualFeatures':'Description,Color',
                'language':'en'}
@@ -26,13 +26,13 @@ subscription_key = "xxxxxxxxxxxxxxxxxxxxxxx"
 image_path = "./TestImages/PolarBear.jpg"
 image_data = open(image_path, 'rb').read()
 
-# According to the documentation for the analyzing image function,
+# According to the documentation for the analyze image function,
 # we need to specify the subscription key and the content type
 # in the HTTP header. Content-Type is application/octet-stream when you pass in a image directly
 headers    = {'Content-Type': 'application/octet-stream',
               'Ocp-Apim-Subscription-Key': subscription_key}
 
-# According to the documentation for the analyzing image function,
+# According to the documentation for the analyze image function,
 # we use HTTP POST to call this function
 response = requests.post(address, headers=headers, params=parameters, data=image_data)
 


### PR DESCRIPTION
I fixed some typing, grammar, and indenting errors of comments in python-for-beginners chapter 11 to 18.